### PR TITLE
Add support for FreeBSD/OSX and Mac M1, replace urandom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 
 # compiler and flags
 CC := gcc
-CFLAGS := -march=native -Wall -Wextra -Wshadow -Wundef
+CFLAGS := -Wall -Wextra -Wshadow -Wundef
 CFLAGS_DEBUG   := -g3
 CFLAGS_RELEASE := -O3
 CFLAGS_RUNTIME := $(CFLAGS_DEBUG) $(CFLAGS)
@@ -23,6 +23,15 @@ RM := del /q /f
 else
 PATH_SEP := /
 RM := rm -f
+endif
+
+# check for apple M1
+ARCH := $(shell uname -m)
+PLATFORM := $(shell uname -s)
+ifeq "$(PLATFORM) $(ARCH)" "Darwin arm64"
+	CFLAGS += -mcpu=apple-m1
+else
+	CFLAGS += -march=native
 endif
 
 .PHONY: all release set_release_flags run clean

--- a/crand.c
+++ b/crand.c
@@ -13,12 +13,32 @@
 		return CRAND_SUCCESS;
 	}
 #elif defined __unix__ || defined __APPLE__ && defined __MACH__
-	#include <stdlib.h>
+    #if !defined __GLIBC__ || __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 36
+        int rand_bytes(void *buf, size_t n){
+            arc4random_buf(buf, n);
+            return CRAND_SUCCESS;
+        }
+    #else
+        #define URANDOM_PATH "/dev/urandom"
+        static FILE *urandom = NULL;
 
-	int rand_bytes(void *buf, size_t n){
-		arc4random_buf(buf, n);
-		return CRAND_SUCCESS;
-	}
+        void urandom_close(){
+            fclose(urandom);
+        }
+
+        int rand_bytes(void *buf, size_t n){
+            if(urandom == NULL){
+                if((urandom = fopen(URANDOM_PATH, "r")) == NULL)
+                    return CRAND_FAILURE;
+                else
+                    atexit(urandom_close);
+            }
+
+            if(fread(buf, 1, n, urandom) != n)
+                return CRAND_FAILURE;
+            return CRAND_SUCCESS;
+        }
+    #endif
 #else
 	#error Unsupported platform.
 #endif

--- a/crand.c
+++ b/crand.c
@@ -12,24 +12,11 @@
 			return CRAND_FAILURE;
 		return CRAND_SUCCESS;
 	}
-#elif defined __unix__
-	#define URANDOM_PATH "/dev/urandom"
-	static FILE *urandom = NULL;
-
-	void urandom_close(){
-		fclose(urandom);
-	}
+#elif defined __unix__ || defined __APPLE__ && defined __MACH__
+	#include <stdlib.h>
 
 	int rand_bytes(void *buf, size_t n){
-		if(urandom == NULL){
-			if((urandom = fopen(URANDOM_PATH, "r")) == NULL)
-				return CRAND_FAILURE;
-			else
-				atexit(urandom_close);
-		}
-		
-		if(fread(buf, 1, n, urandom) != n)
-			return CRAND_FAILURE;
+		arc4random_buf(buf, n);
 		return CRAND_SUCCESS;
 	}
 #else


### PR DESCRIPTION
Replaces reading from /dev/urandom by a call to [arc4random](https://man.openbsd.org/arc4random.3).
From [random(4) man page](https://man.openbsd.org/random.4):
> The urandom device is intended to be used in scripts. In C programs, use the arc4random(3) family of functions instead, which can be called in almost all coding environments, including pthreads(3), chroot(2), pledge(2), and unveil(2), and which avoids accessing a filesystem device every time.

This also adds support for BSD-based systems like DragonFly BSD, FreeBSD, OpenBSD, NetBSD and OSX-based systems, including iOS.

Also modifies the makefile to allow compiling on arm64 OSX with apple clang, fixing the `the clang compiler does not support '-march=native'` error.